### PR TITLE
Fix symlinks patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ starting location of the left and right pane respectively.
 
 ## [sort-ignoredot](sort-ignoredot/sfm-sort-ignoredot-0.3.1.diff)
 Adds an option to ignore the leading dot character in 'dotfiles' when sorting them.
+
+## [symlinks](sfm-symlinks-0.4.diff)
+
+* hide symlinks (resolved full name) from files list
+* show full symlink name on bottom status line when actual symlink selected

--- a/sfm-symlinks-0.4.diff
+++ b/sfm-symlinks-0.4.diff
@@ -1,29 +1,30 @@
-From 07e564f2d61d9a5dac0e657d66d9877a0be612c4 Mon Sep 17 00:00:00 2001
-From: Nikolay Korotkiy <sikmir@gmail.com>
-Date: Thu, 18 Nov 2021 10:48:57 +0300
+From 0285b3f1a874d83c12fd54a278319716289c7137 Mon Sep 17 00:00:00 2001
+From: Nikolay Korotkiy <sikmir@disroot.org>
+Date: Sun, 20 Mar 2022 00:23:03 +0300
 Subject: [PATCH] Hide symlinks
 
 * hide symlinks (resolved full name) from files list
 * show full symlink name on bottom status line when actual symlink selected
 ---
- sfm.c | 29 +++++++++++++++--------------
- 1 file changed, 15 insertions(+), 14 deletions(-)
+ sfm.c | 31 +++++++++++++++++--------------
+ 1 file changed, 17 insertions(+), 14 deletions(-)
 
 diff --git a/sfm.c b/sfm.c
-index 3a69586..cea2bc1 100644
+index 3a69586..819d6f0 100644
 --- a/sfm.c
 +++ b/sfm.c
-@@ -286,6 +286,9 @@ print_info(Pane *pane, char *dirsize)
+@@ -286,6 +286,10 @@ print_info(Pane *pane, char *dirsize)
  {
  	char *sz, *ur, *gr, *dt, *prm;
  
-+	char *rez_pth;
-+	char lnk_full[MAX_N];
++	char *rez_pth, *lnk_full;
++
++	lnk_full = ecalloc(MAX_N, sizeof(char));
 +
  	dt = ecalloc(MAX_DTF, sizeof(char));
  
  	prm = get_fperm(CURSOR(pane).mode);
-@@ -306,8 +309,17 @@ print_info(Pane *pane, char *dirsize)
+@@ -306,37 +310,36 @@ print_info(Pane *pane, char *dirsize)
  		}
  	}
  
@@ -33,7 +34,7 @@ index 3a69586..cea2bc1 100644
 +		rez_pth = ecalloc(MAX_P, sizeof(char));
 +		if (realpath(CURSOR(pane).name, rez_pth) != NULL) {
 +			snprintf(
-+				lnk_full, MAX_N, " ->%s", rez_pth);
++				lnk_full, MAX_N, "->%s", rez_pth);
 +		}
 +		free(rez_pth);
 +	}
@@ -43,7 +44,13 @@ index 3a69586..cea2bc1 100644
  
  	free(prm);
  	free(ur);
-@@ -320,23 +332,12 @@ static void
+ 	free(gr);
+ 	free(dt);
+ 	free(sz);
++	free(lnk_full);
+ }
+ 
+ static void
  print_row(Pane *pane, size_t entpos, Cpair col)
  {
  	int x, y;
@@ -69,5 +76,5 @@ index 3a69586..cea2bc1 100644
  }
  
 -- 
-2.33.1
+2.35.1
 


### PR DESCRIPTION
1. Remove garbage ("rwxrwxrwx") at the end of status line
Before:
![scr2](https://user-images.githubusercontent.com/688044/159139505-b00ab9f1-b2cb-495e-8262-ade1a59d854d.jpg)
After:
![scr4](https://user-images.githubusercontent.com/688044/159139507-228481ef-5906-47fe-b39b-d86c81f959c1.jpg)
2. Remove extra space before "->" (symlinks have no size)
Before:
![scr1](https://user-images.githubusercontent.com/688044/159139504-2e798bf3-0fe2-413b-bcf8-dba63bae1916.jpg)
After:
![scr3](https://user-images.githubusercontent.com/688044/159139506-a63e07cb-c983-4d5b-b156-a5b576fce276.jpg)
3. Update README